### PR TITLE
remove ipython_genutils from meta.yaml

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
     - mercury=mercury.mercury:main
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -32,7 +32,6 @@ requirements:
     - sqlalchemy ==1.4.27
     - gevent
     - nbconvert >=7.8.0
-    - ipython_genutils
     - django-cors-headers ==3.10.1
     - ipython ==7.30.1
     - ipykernel ==6.6.0


### PR DESCRIPTION
remove ipython_genutils

Really it should not be necessary and this package has been deprecated for 7 years.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.
